### PR TITLE
Fix potential index error in RSS Misc Feeds

### DIFF
--- a/apps/newsmix/news_mix.star
+++ b/apps/newsmix/news_mix.star
@@ -66,7 +66,7 @@ def main(config):
     selected_feeds = {
         config.str("feed1", "WSJ US News"): AVAILABLE_FEEDS[config.str("feed1", "WSJ US News")],
         config.str("feed2", "WSJ World News"): AVAILABLE_FEEDS[config.str("feed2", "WSJ World News")],
-        config.str("feed3", "NYT Home Page"): AVAILABLE_FEEDS[config.str("feed3", "NYT Home Page")],
+        config.str("feed3", "BBC Top Stories"): AVAILABLE_FEEDS[config.str("feed3", "BBC Top Stories")],
     }
 
     feed_names = list(selected_feeds.keys())
@@ -260,7 +260,7 @@ def get_schema():
                     schema.Option(display = name, value = name)
                     for name in AVAILABLE_FEEDS.keys()
                 ],
-                default = "NYT Home Page",
+                default = "BBC Top Stories",
             ),
             schema.Color(
                 id = "header_color",

--- a/apps/newsmix/news_mix.star
+++ b/apps/newsmix/news_mix.star
@@ -23,15 +23,14 @@ AVAILABLE_FEEDS = {
     "WSJ US Business": "https://feeds.content.dowjones.io/public/rss/WSJcomUSBusiness",
     "WSJ Economy": "https://feeds.content.dowjones.io/public/rss/socialeconomyfeed",
     "WSJ Politics": "https://feeds.content.dowjones.io/public/rss/socialpoliticsfeed",
-    # NYT feeds
-    "NYT Home Page": "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-    "NYT World": "https://rss.nytimes.com/services/xml/rss/nyt/World.xml",
-    "NYT Politics": "https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml",
-    "NYT Technology": "https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml",
-    "NYT Business": "https://rss.nytimes.com/services/xml/rss/nyt/Business.xml",
-    "NYT Science": "https://rss.nytimes.com/services/xml/rss/nyt/Science.xml",
+    # Washington Post feeds
+    "WaPo National": "https://feeds.washingtonpost.com/rss/national",
+    "WaPo World": "https://feeds.washingtonpost.com/rss/world",
+    "WaPo Business": "https://feeds.washingtonpost.com/rss/business",
+    "WaPo Technology": "https://feeds.washingtonpost.com/rss/business/technology",
     # Other news sources...
     "BBC Top Stories": "http://feeds.bbci.co.uk/news/rss.xml",
+    "BBC World News": "https://feeds.bbci.co.uk/news/world/rss.xml",
     "CNN Top Stories": "http://rss.cnn.com/rss/cnn_topstories.rss",
     "NPR News": "https://feeds.npr.org/1001/rss.xml",
     "The Guardian": "https://www.theguardian.com/international/rss",

--- a/apps/newsmix/news_mix.star
+++ b/apps/newsmix/news_mix.star
@@ -23,14 +23,15 @@ AVAILABLE_FEEDS = {
     "WSJ US Business": "https://feeds.content.dowjones.io/public/rss/WSJcomUSBusiness",
     "WSJ Economy": "https://feeds.content.dowjones.io/public/rss/socialeconomyfeed",
     "WSJ Politics": "https://feeds.content.dowjones.io/public/rss/socialpoliticsfeed",
-    # Washington Post feeds
-    "WaPo National": "https://feeds.washingtonpost.com/rss/national",
-    "WaPo World": "https://feeds.washingtonpost.com/rss/world",
-    "WaPo Business": "https://feeds.washingtonpost.com/rss/business",
-    "WaPo Technology": "https://feeds.washingtonpost.com/rss/business/technology",
+    # NYT feeds
+    "NYT Home Page": "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+    "NYT World": "https://rss.nytimes.com/services/xml/rss/nyt/World.xml",
+    "NYT Politics": "https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml",
+    "NYT Technology": "https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml",
+    "NYT Business": "https://rss.nytimes.com/services/xml/rss/nyt/Business.xml",
+    "NYT Science": "https://rss.nytimes.com/services/xml/rss/nyt/Science.xml",
     # Other news sources...
     "BBC Top Stories": "http://feeds.bbci.co.uk/news/rss.xml",
-    "BBC World News": "https://feeds.bbci.co.uk/news/world/rss.xml",
     "CNN Top Stories": "http://rss.cnn.com/rss/cnn_topstories.rss",
     "NPR News": "https://feeds.npr.org/1001/rss.xml",
     "The Guardian": "https://www.theguardian.com/international/rss",
@@ -66,7 +67,7 @@ def main(config):
     selected_feeds = {
         config.str("feed1", "WSJ US News"): AVAILABLE_FEEDS[config.str("feed1", "WSJ US News")],
         config.str("feed2", "WSJ World News"): AVAILABLE_FEEDS[config.str("feed2", "WSJ World News")],
-        config.str("feed3", "BBC Top Stories"): AVAILABLE_FEEDS[config.str("feed3", "BBC Top Stories")],
+        config.str("feed3", "NYT Home Page"): AVAILABLE_FEEDS[config.str("feed3", "NYT Home Page")],
     }
 
     feed_names = list(selected_feeds.keys())
@@ -260,7 +261,7 @@ def get_schema():
                     schema.Option(display = name, value = name)
                     for name in AVAILABLE_FEEDS.keys()
                 ],
-                default = "BBC Top Stories",
+                default = "NYT Home Page",
             ),
             schema.Color(
                 id = "header_color",

--- a/apps/rssmiscfeeds/rss_misc_feeds.star
+++ b/apps/rssmiscfeeds/rss_misc_feeds.star
@@ -101,7 +101,7 @@ def get_schema():
                 name = "RSS Feed",
                 desc = "Select which feed to display",
                 icon = "newspaper",
-                default = feed_options[1].value,
+                default = feed_options[0].value if feed_options else "",
                 options = feed_options,
             ),
             schema.Dropdown(


### PR DESCRIPTION
## Summary
- Fix a potential index error in the RSS Misc Feeds app
- Previously, the code used `feed_options[1].value` (second option) as default, which would cause an index error if there was only one feed option
- Now uses the first option (`feed_options[0]`) with a fallback to empty string if no options exist

## Test plan
- Verify the app works correctly when the feed options list has:
  - Multiple feed options (should use first option)
  - Only one feed option (should use that option)
  - No feed options (should use empty string)

🤖 Generated with [Claude Code](https://claude.ai/code)